### PR TITLE
Changed argument name in ctapipe.instrument.telescope.TelescopeDescription

### DIFF
--- a/ctapipe_io_nectarcam/__init__.py
+++ b/ctapipe_io_nectarcam/__init__.py
@@ -97,7 +97,7 @@ class NectarCAMEventSource(EventSource):
             geometry_version = 2
             camera = CameraGeometry.from_name("NectarCam", geometry_version)
 
-            tel_descr = TelescopeDescription(name='MST', type='NectarCam', optics=optics, camera=camera)
+            tel_descr = TelescopeDescription(name='MST', tel_type='NectarCam', optics=optics, camera=camera)
 
             tel_descr.optics.tel_subtype = ''  # to correct bug in reading
 


### PR DESCRIPTION
In the current ctapipe master (0.6.2.post169), the argument for the telescope type changed compared to the current use in `ctapipe_io_nectarcam`.