### PR TITLE
Updating protozfitsreader version to read native charges.

### DIFF
--- a/ctapipe_io_nectarcam/__init__.py
+++ b/ctapipe_io_nectarcam/__init__.py
@@ -2,7 +2,7 @@
 """
 EventSource for LSTCam protobuf-fits.fz-files.
 
-Needs protozfits v1.4.2 from github.com/cta-sst-1m/protozfitsreader
+Needs protozfits v1.5.0 from github.com/cta-sst-1m/protozfitsreader
 """
 
 import numpy as np

--- a/py3.6_env.yaml
+++ b/py3.6_env.yaml
@@ -30,6 +30,6 @@ dependencies:
   - pip:
       - pytest_runner
       - https://github.com/cta-observatory/ctapipe-extra/archive/v0.2.16.tar.gz
-      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz
+      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz
       # master at 22.02.2019
       - git+git://github.com/cta-observatory/ctapipe.git@ef14205fa9f7be7028839d50b335eb9be1b16092

--- a/py3.7_env.yaml
+++ b/py3.7_env.yaml
@@ -30,6 +30,6 @@ dependencies:
   - pip:
       - pytest_runner
       - https://github.com/cta-observatory/ctapipe-extra/archive/v0.2.16.tar.gz
-      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz
+      - https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz
       # master at 22.02.2019
       - git+git://github.com/cta-observatory/ctapipe.git@ef14205fa9f7be7028839d50b335eb9be1b16092

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         'astropy',
         'ctapipe',
-        'protozfits',
+        'protozfits @ https://github.com/cta-sst-1m/protozfitsreader/archive/v1.5.0.tar.gz',
     ],
     tests_require=['pytest'],
     setup_requires=['pytest_runner'],


### PR DESCRIPTION
Update to latest reader is necessary to avoid warnings when reading the latest data files and read native charges. See https://github.com/cta-sst-1m/protozfitsreader/issues/62