### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - zeromq
   - ipython
   - numba
-  - numpy~=1.22.4 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
+  - numpy=1.22.4 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
   - numpydoc
   - pytest
   - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - zeromq
   - ipython
   - numba
-  - numpy=1.22.4 # higher versions don't work: Maxnoe: "ctapipe 0.12 depends on astropy 4, which is incompatible with the most recent numpy release 1.23"
+  - numpy=1.22 # higher versions don't work due to astropy4 dependency in ctapipe0.12
   - numpydoc
   - pytest
   - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - zeromq
   - ipython
   - numba
-  - numpy>=1.18
+  - numpy=1.22.4 # higher versions don't work: Maxnoe: "ctapipe 0.12 depends on astropy 4, which is incompatible with the most recent numpy release 1.23"
   - numpydoc
   - pytest
   - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - zeromq
   - ipython
   - numba
-  - numpy=1.22 # higher versions don't work due to astropy4 dependency in ctapipe0.12
+  - numpy~=1.22.4 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
   - numpydoc
   - pytest
   - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - zeromq
   - ipython
   - numba
-  - numpy=1.22.4 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
+  - numpy=1.22 # higher versions >=1.23 don't work due to astropy4 dependency in ctapipe0.12
   - numpydoc
   - pytest
   - pyyaml

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     install_requires=[
         'astropy~=4.2',
         'ctapipe~=0.12',
+        'numpy~=1.22.4',
         'protozfits~=2.0',
         'setuptools_scm',
     ],


### PR DESCRIPTION
Have to pin numpy to 1.22, as @maxnoe remarks "ctapipe 0.12 depends on astropy 4, which is incompatible with the most recent numpy release 1.23"