### PR TITLE
Updated python and ctapipe versions for GitHub CI, to address #28.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
-        ctapipe-version: [v0.10.0]
+        python-version: [3.8]
+        ctapipe-version: [v0.12.0]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Hi,
This PR is meant to address #28.
The CI passes for this branch in my forked repo.
Thanks !