### PR TITLE
Entry point for NectarCAMEventSource into ctapipe.io

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ all = [
     "ctapipe_io_nectarcam[test,dev]",
 ]
 
+[project.entry-points.ctapipe_io]
+NectarCAMEventSource = "ctapipe_io_nectarcam:NectarCAMEventSource"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 exclude = ["ctapipe_io_nectarcam._dev_version"]


### PR DESCRIPTION
As reported in #52 , an entry point is missing to directly use the `ctapipe.io` plugin functionality for `NectarCAMEventSource`. This PR should address this.

One needs to uninstall/re-install `ctapipe_io_nectarcam` to test this:
```
pip uninstall ctapipe-io-nectarcam
pip install -e .
```