### PR TITLE
Add BlockNectarCAMEventSource class

### DIFF
--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -9,7 +9,6 @@ import glob
 import os
 import re
 import struct
-import types
 from collections.abc import Iterable
 from enum import IntFlag, auto
 
@@ -1336,31 +1335,27 @@ class BlockNectarCAMEventSource:
             self.allowed_blocks = None
 
         if "input_url" in self._arguments.keys():
+            # give list to NectarCAMEventSource so remove it from arguments
             self._file_names = glob.glob(kwargs["input_url"])
             self._file_names.sort()
-            del self._arguments[
-                "input_url"
-            ]  # We'll give the list to the NectarCAMEventSource so remove it from the arguments
+            del self._arguments["input_url"]
         elif "input_filelist" in self._arguments.keys():
+            # give list to NectarCAMEventSource so remove it from arguments
             self._file_names = kwargs["input_filelist"]
             self._file_names.sort()
-            del self._arguments[
-                "input_filelist"
-            ]  # We'll give the list to the NectarCAMEventSource so remove it from the arguments
+            del self._arguments["input_filelist"]
         else:
             raise ValueError("No input_irl or input_filelist given !")
 
         if "max_events" in self._arguments.keys():
+            # treating option here, don't forward it to NectarCAMEventSource
             self.max_events = int(kwargs["max_events"])
-            del self._arguments[
-                "max_events"
-            ]  # we are treating this option here, so don't forward it to NectarCAMEventSource
+            del self._arguments["max_events"]
 
         if "show_empty_stats" in self._arguments.keys():
+            # treating option here, don't forward it to NectarCAMEventSource
             self.show_empty_stats = bool(kwargs["show_empty_stats"])
-            del self._arguments[
-                "show_empty_stats"
-            ]  # we are treating this option here, so don't forward it to NectarCAMEventSource
+            del self._arguments["show_empty_stats"]
 
         self._create_blocks()
         self._switch_block()
@@ -1370,8 +1365,7 @@ class BlockNectarCAMEventSource:
         # More careful checks are needed to know if this truly works...
         if hasattr(self._current_source, attr):
             attr_val = getattr(self._current_source, attr)
-            attr_type = type(attr_val)
-            if attr_type == types.MethodType or attr_type == types.FunctionType:
+            if callable(attr_val):
 
                 def call_wrapper(*args, **kwargs):
                     return getattr(self._current_source, attr)(*args, **kwargs)
@@ -1433,7 +1427,7 @@ class BlockNectarCAMEventSource:
                 for block in self.allowed_blocks:
                     if block < len(block_list):
                         filtered_blocks.append(block_list[block])
-                ## Sanity check --> Remove duplicated entries
+                # Sanity check --> Remove duplicated entries
                 filtered_blocks = [
                     x
                     for n, x in enumerate(filtered_blocks)
@@ -1491,7 +1485,10 @@ class BlockNectarCAMEventSource:
     def print_empty_stats(self):
         if self.empty_entries > 0:
             print(
-                f"WARNING> Empty events : {self.empty_entries}/{self.get_entries()} --> {100.*self.empty_entries/self.get_entries():.2f} %"
+                f"WARNING> Empty events :"
+                f" {self.empty_entries}/{self.get_entries()}"
+                f" --> "
+                f"{100.*self.empty_entries/self.get_entries():.2f} %"
             )
 
 

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1294,9 +1294,22 @@ class LightNectarCAMEventSource(NectarCAMEventSource):
 
 class BlockNectarCAMEventSource:
     """
-    EventSource for long NectarCAMObservations
+    EventSource for long NectarCAMObservations or read specific part of the run.
+    The grouping is only done if the number of files is a multiple of the block_size.
+    It is also possible to analyse only certain blocks via the allowed_blocks argument.
+
+    The grouping has the advantage of not opening all files at the same time. 
+
     At the moment, it's a standalone class to have better control on what is done.
-    TODO : Study if it could inherit from EventSource., 
+    TODO : Study if it could inherit from EventSource.,
+
+    Input:
+        block_size: The number of file per group.
+            default: 4
+
+        allowed_blocks : id or list of id of block to analyse
+            default: None (all analysed)
+
     """
 
     def __init__(self,block_size=4,allowed_blocks=None,**kwargs):

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1401,7 +1401,8 @@ class BlockNectarCAMEventSource:
 
         if len(self._file_names) % self.block_size !=0 or not self.consecutive_files(self._file_names):
             print("Not possible to block --> Read everything")
-            block_list = list( self._file_names )
+            block_list = list()
+            block_list.append( list( self._file_names ) )
         else:
             block_list = list()
             nBlocks = len(self._file_names)//self.block_size

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -6,8 +6,11 @@ Needs protozfits v1.5.0 from github.com/cta-sst-1m/protozfitsreader
 """
 
 import glob
+import os
 import re
 import struct
+import types
+from collections.abc import Iterable
 from enum import IntFlag, auto
 
 import numpy as np
@@ -38,6 +41,7 @@ from ctapipe.instrument import (
 )
 from ctapipe.io import DataLevel, EventSource
 from pkg_resources import resource_filename
+from protozfits import File
 from traitlets.config import Config
 
 from .anyarray_dtypes import CDTS_AFTER_37201_DTYPE, CDTS_BEFORE_37201_DTYPE, TIB_DTYPE
@@ -49,12 +53,6 @@ from .containers import (
     NectarCAMEventContainer,
     NectarCAMServiceContainer,
 )
-
-from protozfits import File
-import types
-import os
-from collections.abc import Iterable
-
 from .version import __version__
 
 __all__ = ["LightNectarCAMEventSource", "NectarCAMEventSource", "__version__"]
@@ -1292,13 +1290,14 @@ class LightNectarCAMEventSource(NectarCAMEventSource):
         """
         return False
 
+
 class BlockNectarCAMEventSource:
     """
     EventSource for long NectarCAMObservations or read specific part of the run.
     The grouping is only done if the number of files is a multiple of the block_size.
     It is also possible to analyse only certain blocks via the allowed_blocks argument.
 
-    The grouping has the advantage of not opening all files at the same time. 
+    The grouping has the advantage of not opening all files at the same time.
 
     At the moment, it's a standalone class to have better control on what is done.
     TODO : Study if it could inherit from EventSource.,
@@ -1312,65 +1311,75 @@ class BlockNectarCAMEventSource:
 
     """
 
-    def __init__(self,block_size=4,allowed_blocks=None,**kwargs):
-        self._arguments         = kwargs # blocks
-        self._file_names        = None
-        self._block_file_names  = list()
-        self._current_source    = None
-        self._current_block     = None
+    def __init__(self, block_size=4, allowed_blocks=None, **kwargs):
+        self._arguments = kwargs  # blocks
+        self._file_names = None
+        self._block_file_names = list()
+        self._current_source = None
+        self._current_block = None
         self._current_generator = None
-        self._total_entries     = 0
-        self._current_counts    = 0
-        self.block_size         = block_size
-        self.allowed_blocks     = None
-        self.max_events         = None
-        self.empty_entries      = 0
-        self.show_empty_stats   = False 
+        self._total_entries = 0
+        self._current_counts = 0
+        self.block_size = block_size
+        self.allowed_blocks = None
+        self.max_events = None
+        self.empty_entries = 0
+        self.show_empty_stats = False
 
-
-        if isinstance(allowed_blocks,int):            
-            self.allowed_blocks = [allowed_blocks,]
-        elif isinstance(allowed_blocks,Iterable): 
-            self.allowed_blocks = list(set([ int(e) for e in allowed_blocks  ]))
+        if isinstance(allowed_blocks, int):
+            self.allowed_blocks = [
+                allowed_blocks,
+            ]
+        elif isinstance(allowed_blocks, Iterable):
+            self.allowed_blocks = list(set([int(e) for e in allowed_blocks]))
         else:
             self.allowed_blocks = None
 
         if "input_url" in self._arguments.keys():
-            self._file_names = glob.glob(kwargs['input_url'])
+            self._file_names = glob.glob(kwargs["input_url"])
             self._file_names.sort()
-            del self._arguments['input_url'] # We'll give the list to the NectarCAMEventSource so remove it from the arguments
+            del self._arguments[
+                "input_url"
+            ]  # We'll give the list to the NectarCAMEventSource so remove it from the arguments
         elif "input_filelist" in self._arguments.keys():
-            self._file_names = kwargs['input_filelist']
+            self._file_names = kwargs["input_filelist"]
             self._file_names.sort()
-            del self._arguments['input_filelist'] # We'll give the list to the NectarCAMEventSource so remove it from the arguments
+            del self._arguments[
+                "input_filelist"
+            ]  # We'll give the list to the NectarCAMEventSource so remove it from the arguments
         else:
             raise ValueError("No input_irl or input_filelist given !")
 
         if "max_events" in self._arguments.keys():
-            self.max_events = int(kwargs['max_events'])
-            del self._arguments['max_events'] # we are treating this option here, so don't forward it to NectarCAMEventSource
+            self.max_events = int(kwargs["max_events"])
+            del self._arguments[
+                "max_events"
+            ]  # we are treating this option here, so don't forward it to NectarCAMEventSource
 
         if "show_empty_stats" in self._arguments.keys():
-            self.show_empty_stats = bool(kwargs['show_empty_stats'])
-            del self._arguments['show_empty_stats'] # we are treating this option here, so don't forward it to NectarCAMEventSource
-    
+            self.show_empty_stats = bool(kwargs["show_empty_stats"])
+            del self._arguments[
+                "show_empty_stats"
+            ]  # we are treating this option here, so don't forward it to NectarCAMEventSource
 
         self._create_blocks()
         self._switch_block()
 
-    def __getattr__(self,attr):
+    def __getattr__(self, attr):
         # Forward unknown methods to the current NectarCAMEventSource, if it exist
         # More careful checks are needed to know if this truly works...
-        if hasattr(self._current_source,attr):
-            attr_val = getattr(self._current_source,attr)
+        if hasattr(self._current_source, attr):
+            attr_val = getattr(self._current_source, attr)
             attr_type = type(attr_val)
             if attr_type == types.MethodType or attr_type == types.FunctionType:
+
                 def call_wrapper(*args, **kwargs):
                     return getattr(self._current_source, attr)(*args, **kwargs)
+
                 return call_wrapper
             else:
                 return attr_val
-            
+
     def _rewind(self):
         self._current_block = None
         self._switch_block()
@@ -1379,65 +1388,82 @@ class BlockNectarCAMEventSource:
         if self._total_entries == 0:
             for filename in self._file_names:
                 self._total_entries += len(File(str(filename)).Events)
-        return self._total_entries if self.max_events is None else min(self._total_entries,self.max_events)
+        return (
+            self._total_entries
+            if self.max_events is None
+            else min(self._total_entries, self.max_events)
+        )
 
     def _switch_block(self):
         if self._current_block is None:
             self._current_block = 0
-        else: 
+        else:
             self._current_block += 1
-        
+
         valid = False
         if self._current_block < len(self._block_file_names):
-            self._current_source = NectarCAMEventSource(input_filelist=self._block_file_names[self._current_block], **self._arguments)
+            self._current_source = NectarCAMEventSource(
+                input_filelist=self._block_file_names[self._current_block],
+                **self._arguments,
+            )
             self._current_generator = self._current_source._generator()
             valid = True
         return valid
 
     def __len__(self):
         return self.get_entries()
-    
-    def _create_blocks(self):
 
-        if len(self._file_names) % self.block_size !=0 or not self.consecutive_files(self._file_names):
+    def _create_blocks(self):
+        if len(self._file_names) % self.block_size != 0 or not self.consecutive_files(
+            self._file_names
+        ):
             print("Not possible to block --> Read everything")
             block_list = list()
-            block_list.append( list( self._file_names ) )
+            block_list.append(list(self._file_names))
         else:
             block_list = list()
-            nBlocks = len(self._file_names)//self.block_size
+            nBlocks = len(self._file_names) // self.block_size
             for i in range(nBlocks):
-                imin = i*self.block_size
-                imax = (i+1)*self.block_size
-                block_list.append( self._file_names[imin:imax] )
+                imin = i * self.block_size
+                imax = (i + 1) * self.block_size
+                block_list.append(self._file_names[imin:imax])
             if self.allowed_blocks is not None:
                 # going to only take the selected blocks
                 filtered_blocks = list()
                 for block in self.allowed_blocks:
-                    if block<len(block_list):
-                        filtered_blocks.append( block_list[block] )
+                    if block < len(block_list):
+                        filtered_blocks.append(block_list[block])
                 ## Sanity check --> Remove duplicated entries
-                filtered_blocks = [x for n, x in enumerate(filtered_blocks) if x not in filtered_blocks[:n]]
-                filtered_blocks.sort() # just in case
+                filtered_blocks = [
+                    x
+                    for n, x in enumerate(filtered_blocks)
+                    if x not in filtered_blocks[:n]
+                ]
+                filtered_blocks.sort()  # just in case
                 block_list = filtered_blocks
                 # Erase the input list to keep only the selected files
                 self._file_names = [file for block in filtered_blocks for file in block]
-        
+
         self._block_file_names = block_list
 
-    def consecutive_files(self,file_list=None):
+    def consecutive_files(self, file_list=None):
         if file_list is None:
             file_list = self._file_names
         # assume files are of type: 'NectarCAM.Run5665.0246.fits.fz'
         consecutive = False
         try:
-            numbers = np.array([ int(os.path.basename( f ).split('.fits.fz')[0].split('.')[-1]) for f in file_list])
+            numbers = np.array(
+                [
+                    int(os.path.basename(f).split(".fits.fz")[0].split(".")[-1])
+                    for f in file_list
+                ]
+            )
             delta_numbers = numbers[1:] - numbers[:-1]
-            consecutive = np.all( delta_numbers == 1) and numbers[0] == 0
+            consecutive = np.all(delta_numbers == 1) and numbers[0] == 0
         except ValueError:
             consecutive = False
         return consecutive
-    
+
     def __iter__(self):
         self._rewind()
         return self
@@ -1451,7 +1477,7 @@ class BlockNectarCAMEventSource:
             # End of current block, try if there is a next one
             self.empty_entries += self._current_source.get_empty_entries()
             if self._switch_block():
-                next_entry = next( self._current_generator )
+                next_entry = next(self._current_generator)
             else:
                 if self.show_empty_stats:
                     self.print_empty_stats()
@@ -1459,13 +1485,15 @@ class BlockNectarCAMEventSource:
         self._current_counts += 1
         return next_entry
 
-
     def get_empty_entries(self):
         return self.empty_entries
-    
+
     def print_empty_stats(self):
-        if self.empty_entries>0:
-            print(f"WARNING> Empty events : {self.empty_entries}/{self.get_entries()} --> {100.*self.empty_entries/self.get_entries():.2f} %")
+        if self.empty_entries > 0:
+            print(
+                f"WARNING> Empty events : {self.empty_entries}/{self.get_entries()} --> {100.*self.empty_entries/self.get_entries():.2f} %"
+            )
+
 
 class MultiFiles:
     """

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -54,7 +54,12 @@ from .containers import (
 )
 from .version import __version__
 
-__all__ = ["LightNectarCAMEventSource", "NectarCAMEventSource", "__version__"]
+__all__ = [
+    "LightNectarCAMEventSource",
+    "NectarCAMEventSource",
+    "BlockNectarCAMEventSource",
+    "__version__",
+]
 
 S_TO_NS = np.uint64(1e9)
 
@@ -1299,7 +1304,7 @@ class BlockNectarCAMEventSource:
     The grouping has the advantage of not opening all files at the same time.
 
     At the moment, it's a standalone class to have better control on what is done.
-    TODO : Study if it could inherit from EventSource.,
+    Could be made the default behavior of NectarCAMEventSource but need some rewriting.
 
     Input:
         block_size: The number of file per group.
@@ -1336,7 +1341,7 @@ class BlockNectarCAMEventSource:
 
         if "input_url" in self._arguments.keys():
             # give list to NectarCAMEventSource so remove it from arguments
-            self._file_names = glob.glob(kwargs["input_url"])
+            self._file_names = glob.glob(str(kwargs["input_url"]))
             self._file_names.sort()
             del self._arguments["input_url"]
         elif "input_filelist" in self._arguments.keys():
@@ -1359,6 +1364,15 @@ class BlockNectarCAMEventSource:
 
         self._create_blocks()
         self._switch_block()
+
+    @staticmethod
+    def is_compatible(file_path):
+        """
+        This version should only be called directly, so return False
+        such that it is not used when using EventSource.
+        Nevertheless, in principle it should work as NectarCAMEventSource by default.
+        """
+        return False
 
     def __getattr__(self, attr):
         # Forward unknown methods to the current NectarCAMEventSource, if it exist

--- a/src/ctapipe_io_nectarcam/tests/test_nectarcameventsource.py
+++ b/src/ctapipe_io_nectarcam/tests/test_nectarcameventsource.py
@@ -27,9 +27,17 @@ TOTAL_EVENTS = [TOTAL_EVENT_IN_FILE, TOTAL_EVENT_IN_FILE_V6]
 
 
 def test_loop_over_events():
-    from ctapipe_io_nectarcam import LightNectarCAMEventSource, NectarCAMEventSource
+    from ctapipe_io_nectarcam import (
+        BlockNectarCAMEventSource,
+        LightNectarCAMEventSource,
+        NectarCAMEventSource,
+    )
 
-    for event_source in [NectarCAMEventSource, LightNectarCAMEventSource]:
+    for event_source in [
+        NectarCAMEventSource,
+        LightNectarCAMEventSource,
+        BlockNectarCAMEventSource,
+    ]:
         for example_file_path, first_event_number, evt_jump in zip(
             EXAMPLE_FILE_PATHS, FIRST_EVENT_NUMBER_IN_FILES, EVENT_JUMPS
         ):
@@ -51,9 +59,17 @@ def test_loop_over_events():
 
 
 def test_length():
-    from ctapipe_io_nectarcam import LightNectarCAMEventSource, NectarCAMEventSource
+    from ctapipe_io_nectarcam import (
+        BlockNectarCAMEventSource,
+        LightNectarCAMEventSource,
+        NectarCAMEventSource,
+    )
 
-    for event_source in [NectarCAMEventSource, LightNectarCAMEventSource]:
+    for event_source in [
+        NectarCAMEventSource,
+        LightNectarCAMEventSource,
+        BlockNectarCAMEventSource,
+    ]:
         for example_file_path, total_event in zip(EXAMPLE_FILE_PATHS, TOTAL_EVENTS):
             inputfile_reader = event_source(input_url=example_file_path)
             assert len(inputfile_reader) == total_event
@@ -61,10 +77,18 @@ def test_length():
 
 
 def test_length_with_limit():
-    from ctapipe_io_nectarcam import LightNectarCAMEventSource, NectarCAMEventSource
+    from ctapipe_io_nectarcam import (
+        BlockNectarCAMEventSource,
+        LightNectarCAMEventSource,
+        NectarCAMEventSource,
+    )
 
     n_events = 10
-    for event_source in [NectarCAMEventSource, LightNectarCAMEventSource]:
+    for event_source in [
+        NectarCAMEventSource,
+        LightNectarCAMEventSource,
+        BlockNectarCAMEventSource,
+    ]:
         for example_file_path in EXAMPLE_FILE_PATHS:
             inputfile_reader = event_source(
                 input_url=example_file_path, max_events=n_events
@@ -74,9 +98,17 @@ def test_length_with_limit():
 
 
 def test_identification():
-    from ctapipe_io_nectarcam import LightNectarCAMEventSource, NectarCAMEventSource
+    from ctapipe_io_nectarcam import (
+        BlockNectarCAMEventSource,
+        LightNectarCAMEventSource,
+        NectarCAMEventSource,
+    )
 
-    for event_source in [NectarCAMEventSource, LightNectarCAMEventSource]:
+    for event_source in [
+        NectarCAMEventSource,
+        LightNectarCAMEventSource,
+        BlockNectarCAMEventSource,
+    ]:
         inputfile_reader = event_source(
             input_url=EXAMPLE_FILE_PATH,
         )
@@ -84,9 +116,17 @@ def test_identification():
 
 
 def test_v6_identification():
-    from ctapipe_io_nectarcam import LightNectarCAMEventSource, NectarCAMEventSource
+    from ctapipe_io_nectarcam import (
+        BlockNectarCAMEventSource,
+        LightNectarCAMEventSource,
+        NectarCAMEventSource,
+    )
 
-    for event_source in [NectarCAMEventSource, LightNectarCAMEventSource]:
+    for event_source in [
+        NectarCAMEventSource,
+        LightNectarCAMEventSource,
+        BlockNectarCAMEventSource,
+    ]:
         inputfile_reader = event_source(
             input_url=EXAMPLE_FILE_PATH_V6,
         )
@@ -117,9 +157,17 @@ def test_factory_for_nectarcam_file():
 
 
 def test_subarray():
-    from ctapipe_io_nectarcam import LightNectarCAMEventSource, NectarCAMEventSource
+    from ctapipe_io_nectarcam import (
+        BlockNectarCAMEventSource,
+        LightNectarCAMEventSource,
+        NectarCAMEventSource,
+    )
 
-    for event_source in [NectarCAMEventSource, LightNectarCAMEventSource]:
+    for event_source in [
+        NectarCAMEventSource,
+        LightNectarCAMEventSource,
+        BlockNectarCAMEventSource,
+    ]:
         for example_file_path in EXAMPLE_FILE_PATHS:
             n_events = 10
             inputfile_reader = event_source(
@@ -150,47 +198,58 @@ def test_time_precision():
 
 
 def test_r1_waveforms():
-    from ctapipe_io_nectarcam import NectarCAMEventSource
+    from ctapipe_io_nectarcam import (
+        BlockNectarCAMEventSource,
+        LightNectarCAMEventSource,
+        NectarCAMEventSource,
+    )
 
-    for example_file_path in EXAMPLE_FILE_PATHS:
-        # without gain selection
-        config = Config(
-            dict(
-                NectarCAMEventSource=dict(
-                    NectarCAMR0Corrections=dict(
-                        select_gain=False,
+    #    from ctapipe_io_nectarcam import NectarCAMEventSource
+
+    for event_source in [
+        NectarCAMEventSource,
+        LightNectarCAMEventSource,
+        BlockNectarCAMEventSource,
+    ]:
+        for example_file_path in EXAMPLE_FILE_PATHS:
+            # without gain selection
+            config = Config(
+                dict(
+                    NectarCAMEventSource=dict(
+                        NectarCAMR0Corrections=dict(
+                            select_gain=False,
+                        )
                     )
                 )
             )
-        )
 
-        n_events = 10
-        inputfile_reader = NectarCAMEventSource(
-            input_url=example_file_path, max_events=n_events, config=config
-        )
+            n_events = 10
+            inputfile_reader = event_source(
+                input_url=example_file_path, max_events=n_events, config=config
+            )
 
-        waveform_shape = (N_GAINS, N_PIXELS, N_SAMPLES)
-        for event in inputfile_reader:
-            for telid in event.trigger.tels_with_trigger:
-                assert event.r1.tel[telid].waveform.shape == waveform_shape
+            waveform_shape = (N_GAINS, N_PIXELS, N_SAMPLES)
+            for event in inputfile_reader:
+                for telid in event.trigger.tels_with_trigger:
+                    assert event.r1.tel[telid].waveform.shape == waveform_shape
 
-        # with gain selection
-        config = Config(
-            dict(
-                NectarCAMEventSource=dict(
-                    NectarCAMR0Corrections=dict(
-                        select_gain=True,
+            # with gain selection
+            config = Config(
+                dict(
+                    NectarCAMEventSource=dict(
+                        NectarCAMR0Corrections=dict(
+                            select_gain=True,
+                        )
                     )
                 )
             )
-        )
 
-        n_events = 10
-        inputfile_reader = NectarCAMEventSource(
-            input_url=example_file_path, max_events=n_events, config=config
-        )
+            n_events = 10
+            inputfile_reader = event_source(
+                input_url=example_file_path, max_events=n_events, config=config
+            )
 
-        waveform_shape = (N_PIXELS, N_SAMPLES)
-        for event in inputfile_reader:
-            for telid in event.trigger.tels_with_trigger:
-                assert event.r1.tel[telid].waveform.shape == waveform_shape
+            waveform_shape = (N_PIXELS, N_SAMPLES)
+            for event in inputfile_reader:
+                for telid in event.trigger.tels_with_trigger:
+                    assert event.r1.tel[telid].waveform.shape == waveform_shape


### PR DESCRIPTION
Will read the data per block instead of all the files together. This remove the limitation of long acquisition that consume too much memory and reach quickly the limit of opened file.

The grouping of the blocks is 4 by default and correspond to the number of data stream of the acquisition.

There is also option to only read a certain set of blocks
