### PR TITLE
Fix a crash in the gain selection with missing packets

### DIFF
--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1179,7 +1179,7 @@ class NectarCAMEventSource(EventSource):
             waveform = np.full(
                 (n_pixels, n_samples), fill, dtype=dtype
             )  # VIM : Replace full by empty ?
-            waveform[not_broken] = zfits_event.waveform.reshape((-1, n_samples))
+            waveform[not_broken] = zfits_event.waveform.reshape((-1, n_samples))[not_broken]
 
             reordered_waveform = np.full(
                 (N_PIXELS, N_SAMPLES), fill, dtype=dtype

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1179,9 +1179,9 @@ class NectarCAMEventSource(EventSource):
             waveform = np.full(
                 (n_pixels, n_samples), fill, dtype=dtype
             )  # VIM : Replace full by empty ?
-            waveform[not_broken] = zfits_event.waveform.reshape(
-                (-1, n_samples)
-            )[not_broken]
+            waveform[not_broken] = zfits_event.waveform.reshape((-1, n_samples))[
+                not_broken
+            ]
 
             reordered_waveform = np.full(
                 (N_PIXELS, N_SAMPLES), fill, dtype=dtype

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1179,7 +1179,9 @@ class NectarCAMEventSource(EventSource):
             waveform = np.full(
                 (n_pixels, n_samples), fill, dtype=dtype
             )  # VIM : Replace full by empty ?
-            waveform[not_broken] = zfits_event.waveform.reshape((-1, n_samples))[not_broken]
+            waveform[not_broken] = zfits_event.waveform.reshape(
+                (-1, n_samples)
+            )[not_broken]
 
             reordered_waveform = np.full(
                 (N_PIXELS, N_SAMPLES), fill, dtype=dtype


### PR DESCRIPTION
This crash occur in case there is gain selection and missing packets.
The `not_broken` mask will have element at False and then it creates a mismatch in shapes.