### PR TITLE
Adapt the pixel_status to the change on the R1 format

### DIFF
--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1269,9 +1269,13 @@ class NectarCAMEventSource(EventSource):
         status_container = array_event.mon.tel[self.tel_id].pixel_status
 
         # reorder the array
-        pixel_status = np.zeros(N_PIXELS)
+        pixel_status = np.zeros(
+            N_PIXELS, dtype=event.pixel_status.dtype
+        )  # pixel status is 8 bit
         pixel_status[self.nectarcam_service.pixel_ids] = event.pixel_status
-        status_container.hardware_failing_pixels[:] = pixel_status == 0
+        # According to A.1.5 of the R1 format, pixel is off/broken/missing
+        # if bit 2 and 3 are at 0.
+        status_container.hardware_failing_pixels[:] = (pixel_status & 0xC) == 0
 
 
 class LightNectarCAMEventSource(NectarCAMEventSource):


### PR DESCRIPTION
According to A.1.5 section of the R1 CTA format, the pixel status contains:
- bit 0 and 1 : DVR Info
- bit 2 and 3 : channel info
- bit 4 : saturation
- bit 5, 6 and 7 : pixel trigger info.

The previous version of the code was assigning the hardware_failing_pixel at True in the pixel_status of the mon object only in the case : pixel_status == 0. 
Nevertheless according to change request : CTA-CRE-ACA-303000-0038, R1 format out of the camera should always put the DVR info at 1, and so on the test does not work anymore.

The proposed changed will use only bit 2 and 3 for the comparison. According to the documentation, if the channel info is 0, then pixel if off/broken/missing. 