### PR TITLE
Upgrade to ctapipe v0.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
-        ctapipe-version: [v0.19.3]
+        python-version: ["3.10", "3.11"]
+        ctapipe-version: [v0.24.0]
 
     defaults:
       run:

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - default
 dependencies:
-  - ctapipe=0.19
+  - ctapipe=0.24
   - h5py
   - ipython
   - numba

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,14 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-    "ctapipe~=0.19",
+    "ctapipe~=0.24.0",
     "protozfits",
-    "scipy==1.11.4",
+    "scipy",
 ]
 
 # needed for setuptools_scm, we don't define a static version

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -965,7 +965,7 @@ class NectarCAMEventSource(EventSource):
 
         if not self.pre_v6_data:
             event_container.first_cell_id = np.full(
-                (N_PIXELS,), np.inf, dtype=event.first_cell_id.dtype
+                (N_PIXELS,), np.nan, dtype=event.first_cell_id.dtype
             )
             event_container.first_cell_id[
                 self.nectarcam_service.pixel_ids

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1189,14 +1189,14 @@ class NectarCAMEventSource(EventSource):
             # print("GAIN SELECTED")
             selected_gain = np.where(has_high_gain, 0, 1)
             waveform = np.full(
-                (N_GAINS, n_pixels, n_samples), fill, dtype=dtype
+                (n_pixels, n_samples), fill, dtype=dtype
             )  # VIM : Replace full by empty ?
             waveform[not_broken] = zfits_event.waveform.reshape((-1, n_samples))[
                 not_broken
             ]
 
             reordered_waveform = np.full(
-                (N_GAINS, N_PIXELS, N_SAMPLES), fill, dtype=dtype
+                (N_PIXELS, N_SAMPLES), fill, dtype=dtype
             )  # VIM : Replace full by empty ?
             reordered_waveform[expected_pixels] = waveform
 

--- a/src/ctapipe_io_nectarcam/constants.py
+++ b/src/ctapipe_io_nectarcam/constants.py
@@ -1,4 +1,6 @@
 import numpy as np
+from astropy import units as u
+from astropy.coordinates.earth import EarthLocation
 
 N_GAINS = 2
 N_MODULES = 265
@@ -9,3 +11,10 @@ HIGH_GAIN = 0
 LOW_GAIN = 1
 
 PIXEL_INDEX = np.arange(N_PIXELS)
+
+# Dummy location for NectarCAM, need for ctapipe.instrument.subarray
+nectarcam_location = EarthLocation(
+    lon=0 * u.deg,
+    lat=0 * u.deg,
+    height=0 * u.m,
+)


### PR DESCRIPTION
This PR propose the big jump from `ctapipe` v0.19 to `ctapipe` v0.24, along with itws twin PR for `nectarchain:
https://github.com/cta-observatory/nectarchain/pull/191

This PR should be ultimately merged **before** https://github.com/cta-observatory/nectarchain/pull/191, with a corresponding release, for `nectarchain` to benefit from it (and not fail in CI).