### PR TITLE
Fix : Create_subarray typo

### DIFF
--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -677,7 +677,7 @@ class NectarCAMEventSource(EventSource):
             name=f"MST-{tel_id} subarray",
             tel_descriptions=tel_descriptions,
             tel_positions=tel_positions,
-            reference_location=nectarcam_location,
+            reference_location=reference_location,
         )
 
         return subarray


### PR DESCRIPTION
reference_location is now properly transmitted