### PR TITLE
R1- and DL0-waveform data model

### DIFF
--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1018,15 +1018,16 @@ class NectarCAMEventSource(EventSource):
 
         # Fill information of the trigger mask in the pixel_status if needed
         # Note that FEB data must have been loaded
-        # if self._missing_trig_pat:
-        #     tpat = np.any(event_container.trigger_pattern, axis=0)
-        #
-        #     event_container.pixel_status = (
-        #         event_container.pixel_status & 0x1F
-        #     )  # Reset the trigger part
-        #     event_container.pixel_status[tpat] = (
-        #         event_container.pixel_status[tpat] | PixelStatus.PIXEL_TRIGGER_1
-        #     )
+        if self._missing_trig_pat:
+            tpat = np.any(event_container.trigger_pattern, axis=0)
+            tpat = tpat[self.nectarcam_service.pixel_ids]
+
+            event_container.pixel_status = (
+                event_container.pixel_status & 0x1F
+            )  # Reset the trigger part
+            event_container.pixel_status[tpat] = (
+                event_container.pixel_status[tpat] | PixelStatus.PIXEL_TRIGGER_1
+            )
 
     def fill_trigger_info(self, array_event):
         tel_id = self.tel_id

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1251,6 +1251,8 @@ class NectarCAMEventSource(EventSource):
                 (N_PIXELS, N_SAMPLES), fill, dtype=dtype
             )  # VIM : Replace full by empty ?
             reordered_waveform[expected_pixels] = waveform
+            # R1- and DL0-waveform data shape should be (n_gains, n_pixels,
+            # n_samples) from ctapipe v0.21 onwards:
             reordered_waveform = reordered_waveform[np.newaxis, ...]
 
             reordered_selected_gain = np.full(N_PIXELS, -1, dtype=np.int8)

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -45,7 +45,7 @@ from traitlets.config import Config
 
 from .anyarray_dtypes import CDTS_AFTER_37201_DTYPE, CDTS_BEFORE_37201_DTYPE, TIB_DTYPE
 from .calibration import NectarCAMR0Corrections
-from .constants import N_GAINS, N_PIXELS, N_SAMPLES, nectarcam_location
+from .constants import N_GAINS, N_PIXELS, N_SAMPLES, N_MODULES, nectarcam_location
 from .containers import (
     NectarCAMDataContainer,
     NectarCAMDataStreamContainer,
@@ -653,13 +653,13 @@ class NectarCAMEventSource(EventSource):
 
     @property
     def datalevels(self):
-        '''
+        """
         TODO: TO BE COMPLETED
         Needs to be updated to take into account different cases
         if select_gain: (R0,R1)
         if input data file is already gain selected: (R1)
         otherwise: (R0)
-        '''
+        """
         if self.r0_r1_calibrator.select_gain:
             return (DataLevel.R0, DataLevel.R1)
         if self.r0_r1_calibrator.calibration_path is not None:
@@ -962,9 +962,21 @@ class NectarCAMEventSource(EventSource):
             # Above info not in Event for v6. Put None instead
 
         event_container.event_id = event.event_id
-        event_container.pixel_status = event.pixel_status
+        zfits_pixel_status = event.pixel_status
+        event_container.pixel_status = np.ones(N_PIXELS, dtype=zfits_pixel_status.dtype)
+        # R1 data should have the bit 0 at 1 according to the R1 data
+        event_container.pixel_status[self.nectarcam_service.pixel_ids] = (
+            zfits_pixel_status
+        )
 
-        event_container.module_status = nectarcam_data.module_status
+        zfits_module_status = nectarcam_data.module_status
+        event_container.module_status = np.zeros(
+            N_MODULES, dtype=zfits_module_status.dtype
+        )
+        # module_status: 1 = present, 0 = absent
+        event_container.module_status[self.nectarcam_service.module_ids] = (
+            zfits_module_status
+        )
         event_container.extdevices_presence = nectarcam_data.extdevices_presence
         event_container.swat_data = nectarcam_data.swat_data
         event_container.counters = nectarcam_data.counters
@@ -1008,19 +1020,19 @@ class NectarCAMEventSource(EventSource):
                 np.iinfo(event.first_cell_id.dtype).max,
                 dtype=event.first_cell_id.dtype,
             )
-            event_container.first_cell_id[
-                self.nectarcam_service.pixel_ids
-            ] = event.first_cell_id
+            event_container.first_cell_id[self.nectarcam_service.pixel_ids] = (
+                event.first_cell_id
+            )
 
         # Unpack FEB counters and trigger pattern
         if self.load_feb_info:
             self.unpack_feb_data(event_container, event, nectarcam_data)
 
         # Fill information of the trigger mask in the pixel_status if needed
-        # Note that FEB data must have been loaded
-        if self._missing_trig_pat:
+        # Note that FEB data must have been loaded.
+        # Should it be forced if _missing_trig_pat is at False ?
+        if self._missing_trig_pat and event_container.trigger_pattern is not None:
             tpat = np.any(event_container.trigger_pattern, axis=0)
-            tpat = tpat[self.nectarcam_service.pixel_ids]
 
             event_container.pixel_status = (
                 event_container.pixel_status & 0x1F
@@ -1133,9 +1145,9 @@ class NectarCAMEventSource(EventSource):
             )
 
         # Unpack absolute event ID
-        event_container.feb_abs_event_id[
-            self.nectarcam_service.module_ids
-        ] = unpacked_feb[0::n_fields]
+        event_container.feb_abs_event_id[self.nectarcam_service.module_ids] = (
+            unpacked_feb[0::n_fields]
+        )
         # Unpack PPS counter
         event_container.feb_pps_cnt[self.nectarcam_service.module_ids] = unpacked_feb[
             1::n_fields
@@ -1151,12 +1163,12 @@ class NectarCAMEventSource(EventSource):
         # Unpack TS2 counters
         ts2_decimal = lambda bits: (bits - (1 << 8) if bits & 0x80 != 0 else bits)
         ts2_decimal_vec = np.vectorize(ts2_decimal)
-        event_container.feb_ts2_trig[
-            self.nectarcam_service.module_ids
-        ] = ts2_decimal_vec(unpacked_feb[4::n_fields])
-        event_container.feb_ts2_pps[
-            self.nectarcam_service.module_ids
-        ] = ts2_decimal_vec(unpacked_feb[5::n_fields])
+        event_container.feb_ts2_trig[self.nectarcam_service.module_ids] = (
+            ts2_decimal_vec(unpacked_feb[4::n_fields])
+        )
+        event_container.feb_ts2_pps[self.nectarcam_service.module_ids] = (
+            ts2_decimal_vec(unpacked_feb[5::n_fields])
+        )
         # Loop over modules
         for module_idx, module_id in enumerate(self.nectarcam_service.module_ids):
             offset = module_id * 7
@@ -1168,9 +1180,9 @@ class NectarCAMEventSource(EventSource):
                     module_pattern = [
                         int(digit) for digit in reversed(bin(value)[2:].zfill(7))
                     ]
-                    event_container.trigger_pattern[
-                        pattern_id, offset : offset + 7
-                    ] = module_pattern
+                    event_container.trigger_pattern[pattern_id, offset : offset + 7] = (
+                        module_pattern
+                    )
 
         # Unpack native charge
         if len(nectarcam_data.charges_gain1) > 0:

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -45,7 +45,7 @@ from traitlets.config import Config
 
 from .anyarray_dtypes import CDTS_AFTER_37201_DTYPE, CDTS_BEFORE_37201_DTYPE, TIB_DTYPE
 from .calibration import NectarCAMR0Corrections
-from .constants import N_GAINS, N_PIXELS, N_SAMPLES, N_MODULES, nectarcam_location
+from .constants import N_GAINS, N_MODULES, N_PIXELS, N_SAMPLES, nectarcam_location
 from .containers import (
     NectarCAMDataContainer,
     NectarCAMDataStreamContainer,
@@ -965,18 +965,18 @@ class NectarCAMEventSource(EventSource):
         zfits_pixel_status = event.pixel_status
         event_container.pixel_status = np.ones(N_PIXELS, dtype=zfits_pixel_status.dtype)
         # R1 data should have the bit 0 at 1 according to the R1 data
-        event_container.pixel_status[self.nectarcam_service.pixel_ids] = (
-            zfits_pixel_status
-        )
+        event_container.pixel_status[
+            self.nectarcam_service.pixel_ids
+        ] = zfits_pixel_status
 
         zfits_module_status = nectarcam_data.module_status
         event_container.module_status = np.zeros(
             N_MODULES, dtype=zfits_module_status.dtype
         )
         # module_status: 1 = present, 0 = absent
-        event_container.module_status[self.nectarcam_service.module_ids] = (
-            zfits_module_status
-        )
+        event_container.module_status[
+            self.nectarcam_service.module_ids
+        ] = zfits_module_status
         event_container.extdevices_presence = nectarcam_data.extdevices_presence
         event_container.swat_data = nectarcam_data.swat_data
         event_container.counters = nectarcam_data.counters
@@ -1020,9 +1020,9 @@ class NectarCAMEventSource(EventSource):
                 np.iinfo(event.first_cell_id.dtype).max,
                 dtype=event.first_cell_id.dtype,
             )
-            event_container.first_cell_id[self.nectarcam_service.pixel_ids] = (
-                event.first_cell_id
-            )
+            event_container.first_cell_id[
+                self.nectarcam_service.pixel_ids
+            ] = event.first_cell_id
 
         # Unpack FEB counters and trigger pattern
         if self.load_feb_info:
@@ -1145,9 +1145,9 @@ class NectarCAMEventSource(EventSource):
             )
 
         # Unpack absolute event ID
-        event_container.feb_abs_event_id[self.nectarcam_service.module_ids] = (
-            unpacked_feb[0::n_fields]
-        )
+        event_container.feb_abs_event_id[
+            self.nectarcam_service.module_ids
+        ] = unpacked_feb[0::n_fields]
         # Unpack PPS counter
         event_container.feb_pps_cnt[self.nectarcam_service.module_ids] = unpacked_feb[
             1::n_fields
@@ -1163,12 +1163,12 @@ class NectarCAMEventSource(EventSource):
         # Unpack TS2 counters
         ts2_decimal = lambda bits: (bits - (1 << 8) if bits & 0x80 != 0 else bits)
         ts2_decimal_vec = np.vectorize(ts2_decimal)
-        event_container.feb_ts2_trig[self.nectarcam_service.module_ids] = (
-            ts2_decimal_vec(unpacked_feb[4::n_fields])
-        )
-        event_container.feb_ts2_pps[self.nectarcam_service.module_ids] = (
-            ts2_decimal_vec(unpacked_feb[5::n_fields])
-        )
+        event_container.feb_ts2_trig[
+            self.nectarcam_service.module_ids
+        ] = ts2_decimal_vec(unpacked_feb[4::n_fields])
+        event_container.feb_ts2_pps[
+            self.nectarcam_service.module_ids
+        ] = ts2_decimal_vec(unpacked_feb[5::n_fields])
         # Loop over modules
         for module_idx, module_id in enumerate(self.nectarcam_service.module_ids):
             offset = module_id * 7
@@ -1180,9 +1180,9 @@ class NectarCAMEventSource(EventSource):
                     module_pattern = [
                         int(digit) for digit in reversed(bin(value)[2:].zfill(7))
                     ]
-                    event_container.trigger_pattern[pattern_id, offset : offset + 7] = (
-                        module_pattern
-                    )
+                    event_container.trigger_pattern[
+                        pattern_id, offset : offset + 7
+                    ] = module_pattern
 
         # Unpack native charge
         if len(nectarcam_data.charges_gain1) > 0:

--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -1018,15 +1018,15 @@ class NectarCAMEventSource(EventSource):
 
         # Fill information of the trigger mask in the pixel_status if needed
         # Note that FEB data must have been loaded
-        if self._missing_trig_pat:
-            tpat = np.any(event_container.trigger_pattern, axis=0)
-
-            event_container.pixel_status = (
-                event_container.pixel_status & 0x1F
-            )  # Reset the trigger part
-            event_container.pixel_status[tpat] = (
-                event_container.pixel_status[tpat] | PixelStatus.PIXEL_TRIGGER_1
-            )
+        # if self._missing_trig_pat:
+        #     tpat = np.any(event_container.trigger_pattern, axis=0)
+        #
+        #     event_container.pixel_status = (
+        #         event_container.pixel_status & 0x1F
+        #     )  # Reset the trigger part
+        #     event_container.pixel_status[tpat] = (
+        #         event_container.pixel_status[tpat] | PixelStatus.PIXEL_TRIGGER_1
+        #     )
 
     def fill_trigger_info(self, array_event):
         tel_id = self.tel_id
@@ -1250,6 +1250,7 @@ class NectarCAMEventSource(EventSource):
                 (N_PIXELS, N_SAMPLES), fill, dtype=dtype
             )  # VIM : Replace full by empty ?
             reordered_waveform[expected_pixels] = waveform
+            reordered_waveform = reordered_waveform[np.newaxis, ...]
 
             reordered_selected_gain = np.full(N_PIXELS, -1, dtype=np.int8)
             reordered_selected_gain[expected_pixels] = selected_gain

--- a/src/ctapipe_io_nectarcam/calibration.py
+++ b/src/ctapipe_io_nectarcam/calibration.py
@@ -130,13 +130,11 @@ class NectarCAMR0Corrections(TelescopeComponent):
             # set r1 waveforms to 0 for broken pixels
             if r1.selected_gain_channel is None:
                 r1.waveform[unusable_pixels] = 0.0
+                r1.pixel_status = np.uint8(unusable_pixels)
             else:
                 r1.waveform[unusable_pixels[r1.selected_gain_channel, PIXEL_INDEX]] = 0.0
+                r1.pixel_status = np.uint8(unusable_pixels[r1.selected_gain_channel])
             r1.waveform = r1.waveform[np.newaxis, ...]
-
-            # TODO: JPL: I guess this is not sufficient:
-            r1.pixel_status = np.uint8(event.mon.tel[
-                tel_id].pixel_status.hardware_failing_pixels[0])
 
             # needed for charge scaling in ctpaipe dl1 calib
             if r1.selected_gain_channel is not None:

--- a/src/ctapipe_io_nectarcam/calibration.py
+++ b/src/ctapipe_io_nectarcam/calibration.py
@@ -48,7 +48,7 @@ class NectarCAMR0Corrections(TelescopeComponent):
     ).tag(config=True)
 
     select_gain = Bool(
-        default_value=False,
+        default_value=True,
         help='Set to False to keep both gains.'
     ).tag(config=True)
 
@@ -132,6 +132,11 @@ class NectarCAMR0Corrections(TelescopeComponent):
                 r1.waveform[unusable_pixels] = 0.0
             else:
                 r1.waveform[unusable_pixels[r1.selected_gain_channel, PIXEL_INDEX]] = 0.0
+            r1.waveform = r1.waveform[np.newaxis, ...]
+
+            # TODO: JPL: I guess this is not sufficient:
+            r1.pixel_status = np.uint8(event.mon.tel[
+                tel_id].pixel_status.hardware_failing_pixels[0])
 
             # needed for charge scaling in ctpaipe dl1 calib
             if r1.selected_gain_channel is not None:

--- a/src/ctapipe_io_nectarcam/calibration.py
+++ b/src/ctapipe_io_nectarcam/calibration.py
@@ -48,7 +48,7 @@ class NectarCAMR0Corrections(TelescopeComponent):
     ).tag(config=True)
 
     select_gain = Bool(
-        default_value=True,
+        default_value=False,
         help='Set to False to keep both gains.'
     ).tag(config=True)
 

--- a/src/ctapipe_io_nectarcam/calibration.py
+++ b/src/ctapipe_io_nectarcam/calibration.py
@@ -1,22 +1,22 @@
 import numpy as np
 import tables
 from ctapipe.calib.camera.gainselection import ThresholdGainSelector
-from ctapipe.containers import MonitoringContainer, MonitoringCameraContainer, FlatFieldContainer, WaveformCalibrationContainer
-from ctapipe.core import TelescopeComponent
-from ctapipe.core.traits import (
-    Path, FloatTelescopeParameter, Bool, Float
+from ctapipe.containers import (
+    FlatFieldContainer,
+    MonitoringCameraContainer,
+    MonitoringContainer,
+    WaveformCalibrationContainer,
 )
+from ctapipe.core import TelescopeComponent
+from ctapipe.core.traits import Bool, Float, FloatTelescopeParameter, Path
 from ctapipe.io import HDF5TableReader
 from pkg_resources import resource_filename
 
-from .constants import (
-    N_GAINS, N_PIXELS, HIGH_GAIN, LOW_GAIN,
-    PIXEL_INDEX,
-)
+from .constants import HIGH_GAIN, LOW_GAIN, N_GAINS, N_PIXELS, PIXEL_INDEX
 from .containers import NectarCAMDataContainer
 
 __all__ = [
-    'NectarCAMR0Corrections',
+    "NectarCAMR0Corrections",
 ]
 
 
@@ -30,36 +30,33 @@ class NectarCAMR0Corrections(TelescopeComponent):
 
     calibration_path = Path(
         default_value=resource_filename(
-            'ctapipe_io_nectarcam',
-            'resources/calibrationfile_run3255_pedrun3255_gainrun3155_ctapipe018.hdf5'
+            "ctapipe_io_nectarcam",
+            "resources/calibrationfile_run3255_pedrun3255_gainrun3155_ctapipe018.hdf5",
         ),
-        exists=True, directory_ok=False, allow_none=True,
-        help='Path to calibration file',
+        exists=True,
+        directory_ok=False,
+        allow_none=True,
+        help="Path to calibration file",
     ).tag(config=True)
 
     calib_scale_high_gain = FloatTelescopeParameter(
-        default_value=1.0,
-        help='High gain waveform is multiplied by this number'
+        default_value=1.0, help="High gain waveform is multiplied by this number"
     ).tag(config=True)
 
     calib_scale_low_gain = FloatTelescopeParameter(
-        default_value=1.0,
-        help='Low gain waveform is multiplied by this number'
+        default_value=1.0, help="Low gain waveform is multiplied by this number"
     ).tag(config=True)
 
     select_gain = Bool(
-        default_value=False,
-        help='Set to False to keep both gains.'
+        default_value=False, help="Set to False to keep both gains."
     ).tag(config=True)
 
     gain_selection_threshold = Float(
-        default_value=3500.,
-        help='Threshold for the ThresholdGainSelector.'
+        default_value=3500.0, help="Threshold for the ThresholdGainSelector."
     ).tag(config=True)
 
     apply_flatfield = Bool(
-        default_value=True,
-        help='Apply flatfielding coefficients.'
+        default_value=True, help="Apply flatfielding coefficients."
     ).tag(config=True)
 
     def __init__(self, subarray, config=None, parent=None, **kwargs):
@@ -69,16 +66,13 @@ class NectarCAMR0Corrections(TelescopeComponent):
         Parameters
         ----------
         """
-        super().__init__(
-            subarray=subarray, config=config, parent=parent, **kwargs
-        )
+        super().__init__(subarray=subarray, config=config, parent=parent, **kwargs)
 
         self.mon_data = None
 
         if self.select_gain:
             self.gain_selector = ThresholdGainSelector(
-                threshold=self.gain_selection_threshold,
-                parent=self
+                threshold=self.gain_selection_threshold, parent=self
             )
         else:
             self.gain_selector = None
@@ -92,7 +86,7 @@ class NectarCAMR0Corrections(TelescopeComponent):
             # check if waveform is already filled
             if r1.waveform is None:
                 r1.waveform = event.r0.tel[tel_id].waveform.copy()
-                # Force a copy as v6 have waveform as float 
+                # Force a copy as v6 have waveform as float
                 # so in this case r0 == r1 (in memory)
 
             r1.waveform = r1.waveform.astype(np.float32, copy=False)
@@ -111,7 +105,7 @@ class NectarCAMR0Corrections(TelescopeComponent):
                 convert_to_pe(
                     waveform=r1.waveform,
                     calibration=calibration,
-                    selected_gain_channel=r1.selected_gain_channel
+                    selected_gain_channel=r1.selected_gain_channel,
                 )
                 # flatfielding
                 if self.apply_flatfield:
@@ -119,30 +113,34 @@ class NectarCAMR0Corrections(TelescopeComponent):
                     apply_flatfield(
                         waveform=r1.waveform,
                         flatfield=flatfield,
-                        selected_gain_channel=r1.selected_gain_channel
+                        selected_gain_channel=r1.selected_gain_channel,
                     )
 
             # do not use pixels that are broken in this run or have unusable calibration
             unusable_pixels = np.logical_and(
                 event.mon.tel[tel_id].pixel_status.hardware_failing_pixels,
-                self.mon_data.tel[tel_id].calibration.unusable_pixels
+                self.mon_data.tel[tel_id].calibration.unusable_pixels,
             )
             # set r1 waveforms to 0 for broken pixels
             if r1.selected_gain_channel is None:
                 r1.waveform[unusable_pixels] = 0.0
                 r1.pixel_status = np.uint8(unusable_pixels)
             else:
-                r1.waveform[unusable_pixels[r1.selected_gain_channel, PIXEL_INDEX]] = 0.0
+                r1.waveform[
+                    unusable_pixels[r1.selected_gain_channel, PIXEL_INDEX]
+                ] = 0.0
                 r1.pixel_status = np.uint8(unusable_pixels[r1.selected_gain_channel])
             r1.waveform = r1.waveform[np.newaxis, ...]
 
             # needed for charge scaling in ctapipe dl1 calib
             if r1.selected_gain_channel is not None:
                 relative_factor = np.empty(N_PIXELS)
-                relative_factor[r1.selected_gain_channel == HIGH_GAIN] = \
-                    self.calib_scale_high_gain.tel[tel_id]
-                relative_factor[r1.selected_gain_channel == LOW_GAIN] = \
-                    self.calib_scale_low_gain.tel[tel_id]
+                relative_factor[
+                    r1.selected_gain_channel == HIGH_GAIN
+                ] = self.calib_scale_high_gain.tel[tel_id]
+                relative_factor[
+                    r1.selected_gain_channel == LOW_GAIN
+                ] = self.calib_scale_low_gain.tel[tel_id]
             else:
                 relative_factor = np.empty((N_GAINS, N_PIXELS))
                 relative_factor[HIGH_GAIN] = self.calib_scale_high_gain.tel[tel_id]
@@ -161,21 +159,27 @@ class NectarCAMR0Corrections(TelescopeComponent):
 
         with tables.open_file(path) as f:
             tel_ids = [
-                int(key[4:]) for key in f.root._v_children.keys()
-                if key.startswith('tel_')
+                int(key[4:])
+                for key in f.root._v_children.keys()
+                if key.startswith("tel_")
             ]
         for tel_id in tel_ids:
             with HDF5TableReader(path) as h5_table:
                 mon.tel[tel_id] = MonitoringCameraContainer(
-                    calibration=next(h5_table.read(f'/tel_{tel_id}/calibration', WaveformCalibrationContainer)),
-                    flatfield=next(h5_table.read(f'/tel_{tel_id}/flatfield', FlatFieldContainer)),
+                    calibration=next(
+                        h5_table.read(
+                            f"/tel_{tel_id}/calibration", WaveformCalibrationContainer
+                        )
+                    ),
+                    flatfield=next(
+                        h5_table.read(f"/tel_{tel_id}/flatfield", FlatFieldContainer)
+                    ),
                 )
 
         return mon
 
 
 def convert_to_pe(waveform, calibration, selected_gain_channel):
-
     if selected_gain_channel is None:
         waveform -= calibration.pedestal_per_sample
         waveform *= calibration.dc_to_pe[:, :, np.newaxis]
@@ -189,4 +193,5 @@ def apply_flatfield(waveform, flatfield, selected_gain_channel):
         waveform *= flatfield.relative_gain_mean[:, :, np.newaxis]
     else:
         waveform *= flatfield.relative_gain_mean[
-            selected_gain_channel, PIXEL_INDEX, np.newaxis]
+            selected_gain_channel, PIXEL_INDEX, np.newaxis
+        ]

--- a/src/ctapipe_io_nectarcam/calibration.py
+++ b/src/ctapipe_io_nectarcam/calibration.py
@@ -136,7 +136,7 @@ class NectarCAMR0Corrections(TelescopeComponent):
                 r1.pixel_status = np.uint8(unusable_pixels[r1.selected_gain_channel])
             r1.waveform = r1.waveform[np.newaxis, ...]
 
-            # needed for charge scaling in ctpaipe dl1 calib
+            # needed for charge scaling in ctapipe dl1 calib
             if r1.selected_gain_channel is not None:
                 relative_factor = np.empty(N_PIXELS)
                 relative_factor[r1.selected_gain_channel == HIGH_GAIN] = \

--- a/src/ctapipe_io_nectarcam/calibration.py
+++ b/src/ctapipe_io_nectarcam/calibration.py
@@ -130,7 +130,7 @@ class NectarCAMR0Corrections(TelescopeComponent):
                     unusable_pixels[r1.selected_gain_channel, PIXEL_INDEX]
                 ] = 0.0
                 r1.pixel_status = np.uint8(unusable_pixels[r1.selected_gain_channel])
-            r1.waveform = r1.waveform[np.newaxis, ...]
+                r1.waveform = r1.waveform[np.newaxis, ...]
 
             # needed for charge scaling in ctapipe dl1 calib
             if r1.selected_gain_channel is not None:

--- a/src/ctapipe_io_nectarcam/tests/test_nectarcameventsource.py
+++ b/src/ctapipe_io_nectarcam/tests/test_nectarcameventsource.py
@@ -249,7 +249,7 @@ def test_r1_waveforms():
                 input_url=example_file_path, max_events=n_events, config=config
             )
 
-            waveform_shape = (N_PIXELS, N_SAMPLES)
+            waveform_shape = (1, N_PIXELS, N_SAMPLES)
             for event in inputfile_reader:
                 for telid in event.trigger.tels_with_trigger:
                     assert event.r1.tel[telid].waveform.shape == waveform_shape


### PR DESCRIPTION
In `ctapipe` 0.21, the expected shape of R1 and DL0 waveforms changed from (n_pixels, n_samples) to be always (n_channels, n_pixels, n_samples) (see https://ctapipe.readthedocs.io/en/latest/changelog.html#id50).

At the moment, `ctapipe_io_nectarcam` is not compatible with the `ctapipe` version v0.24 pinned to it in this respect, as explained in the issue #81.

This PR proposes a fix to this data model change, as well as, incidentally, a fix for the issue #80.

Note: we should be careful in propagating these changes in `nectarchain` as well, presumably by un-doing part of the PR https://github.com/cta-observatory/nectarchain/pull/191.