### PR TITLE
Add option to read calibrated R0 data

### DIFF
--- a/src/ctapipe_io_nectarcam/__init__.py
+++ b/src/ctapipe_io_nectarcam/__init__.py
@@ -653,6 +653,15 @@ class NectarCAMEventSource(EventSource):
 
     @property
     def datalevels(self):
+        '''
+        TODO: TO BE COMPLETED
+        Needs to be updated to take into account different cases
+        if select_gain: (R0,R1)
+        if input data file is already gain selected: (R1)
+        otherwise: (R0)
+        '''
+        if self.r0_r1_calibrator.select_gain:
+            return (DataLevel.R0, DataLevel.R1)
         if self.r0_r1_calibrator.calibration_path is not None:
             return (DataLevel.R0, DataLevel.R1)
         return (DataLevel.R0,)


### PR DESCRIPTION
Small addition to correctly fill the R1 container when `NectarCAMR0Corrections.select_gain = True`. If `NectarCAMR0Corrections.calibration_path = None`, the R1 container will be a copy of the R0 container for the selected gain channel. This allows us to correctly read "calibrated R0 data" that has not been gain selected at the EVB level (such as in [run 571](http://nectarcam.in2p3.fr/elog/nectarcam-data-cam2/230) of NectarCAM2).

Note that we will have to add more options in the future to correctly read true R1 data from the EVB for different data types (NSB,...). 