### PR TITLE
Drop support for python 3.10 and 3.11, bump python prod version to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12"]
         ctapipe-version: [v0.24.0]
 
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.12", "3.13", "3.14"]
         ctapipe-version: [v0.24.0]
 
     defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: black-jupyter
   # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         args: [--max-line-length=88, "--extend-ignore=E203,E712,E731"]

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - default
 dependencies:
-  - python=3.14
+  - python=3.12
   - ctapipe=0.24
   - h5py
   - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - default
 dependencies:
-  - ptyhon=3.14
+  - python=3.14
   - ctapipe=0.24
   - h5py
   - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - default
 dependencies:
+  - ptyhon=3.14
   - ctapipe=0.24
   - h5py
   - ipython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14"
+    "Programming Language :: Python :: 3.12"
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "ctapipe~=0.24.0",
     "protozfits",
     "scipy",
+    "setuptools<81",
 ]
 
 # needed for setuptools_scm, we don't define a static version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "ctapipe~=0.24.0",
     "protozfits",


### PR DESCRIPTION
This PR bumps the python version to 3.12 for our production environment for `ctapipe_io_nectarcam`.

It also removes support for python versions 3.10 and 3.11.

N.B.: this PR is a prerequisite before merging the PR https://github.com/cta-observatory/nectarchain/pull/354 on the `nectarchain` side.